### PR TITLE
fix: libsds received signal

### DIFF
--- a/library/sds_thread/sds_thread.nim
+++ b/library/sds_thread/sds_thread.nim
@@ -41,12 +41,12 @@ proc runSds(ctx: ptr SdsContext) {.async.} =
       error "sds thread could not receive a request"
       continue
 
+    ## Handle the request
+    asyncSpawn SdsThreadRequest.process(request, addr rm)
+
     let fireRes = ctx.reqReceivedSignal.fireSync()
     if fireRes.isErr():
       error "could not fireSync back to requester thread", error = fireRes.error
-
-    ## Handle the request
-    asyncSpawn SdsThreadRequest.process(request, addr rm)
 
 proc run(ctx: ptr SdsContext) {.thread.} =
   ## Launch sds worker


### PR DESCRIPTION
Sending received signal in libsds only after the request is processed (same fix as https://github.com/waku-org/nwaku/pull/3507)
