### PR TITLE
fix: add channelID to SdsUnwrapResponse

### DIFF
--- a/library/sds_thread/inter_thread_communication/requests/sds_message_request.nim
+++ b/library/sds_thread/inter_thread_communication/requests/sds_message_request.nim
@@ -18,6 +18,7 @@ type SdsMessageRequest* = object
 type SdsUnwrapResponse* = object
   message*: seq[byte]
   missingDeps*: seq[SdsMessageID]
+  channelId*: string
 
 proc createShared*(
     T: type SdsMessageRequest,
@@ -61,11 +62,11 @@ proc process*(
   of UNWRAP_MESSAGE:
     let messageBytes = self.message.toSeq()
 
-    let (unwrappedMessage, missingDeps, _) = unwrapReceivedMessage(rm[], messageBytes).valueOr:
+    let (unwrappedMessage, missingDeps, channelId) = unwrapReceivedMessage(rm[], messageBytes).valueOr:
       error "UNWRAP_MESSAGE failed", error = error
       return err("error processing UNWRAP_MESSAGE request: " & $error)
 
-    let res = SdsUnwrapResponse(message: unwrappedMessage, missingDeps: missingDeps)
+    let res = SdsUnwrapResponse(message: unwrappedMessage, missingDeps: missingDeps, channelId: channelId)
 
     # return the result as a json string
     return ok($(%*(res)))


### PR DESCRIPTION
This is a minor fix noticed while running the tests in sds-go-bindings for https://github.com/waku-org/sds-go-bindings/pull/5