### PR TITLE
nix: add Gh workflow for building Flake packages

### DIFF
--- a/.github/workflows/nix-builds.yml
+++ b/.github/workflows/nix-builds.yml
@@ -1,0 +1,25 @@
+---
+name: ci / nix-builds
+on:
+  pull_request:
+    branches: [master]
+jobs:
+  build:
+    name: Build Nix Flake packages
+    runs-on: [self-hosted, Linux]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build library
+        shell: bash
+        run: |
+          nix build '.?submodules=1#libsds' \
+            --print-out-paths --accept-flake-config
+
+      - name: Build Android library
+        shell: bash
+        run: |
+          nix build '.?submodules=1#libsds-android-arm64' \
+            --print-out-paths --accept-flake-config


### PR DESCRIPTION
Important if `status-go` is consume the Nix Flake.