### PR TITLE
nix: do not add android SDK on aarch64 Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,5 +65,12 @@
           targets = [ name ];
         };
       }) targets));
+
+      devShells = forAllSystems (system: let
+        pkgs = pkgsFor.${system};
+      in {
+        default = pkgs.callPackage ./nix/shell.nix { } ;
+      });
     };
+
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -88,5 +88,3 @@ in stdenv.mkDerivation rec {
     platforms = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" "x86_64-windows"];
   };
 }
-
-

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -2,21 +2,22 @@
   pkgs ? import <nixpkgs> { },
 }:
 let
-  optionalDarwinDeps = pkgs.lib.optionals pkgs.stdenv.isDarwin [
-    pkgs.libiconv
-    pkgs.darwin.apple_sdk.frameworks.Security
-  ];
-in
-pkgs.mkShell {
-  inputsFrom = [
+  inherit (pkgs) lib stdenv;
+  /* No Android SDK for Darwin aarch64. */
+  isMacM1 = stdenv.isDarwin && stdenv.isAarch64;
+
+in pkgs.mkShell {
+  inputsFrom = lib.optionals (!isMacM1) [
     pkgs.androidShell
-  ] ++ optionalDarwinDeps;
+  ];
 
   buildInputs = with pkgs; [
     which
     git
     cmake
     nim-unwrapped-2_2
+  ] ++ lib.optionals stdenv.isDarwin [
+    pkgs.libiconv
   ];
 
   # Avoid compiling Nim itself.


### PR DESCRIPTION
Otherwise it fails with:
```
error: aarch64-darwin not supported for Android SDK. Use: NIXPKGS_SYSTEM_OVERRIDE=x86_64-darwin
```