### PR TITLE
nix: fix Android builds on Darwin platforms

### DIFF
--- a/nix/pkgs/android-sdk/compose.nix
+++ b/nix/pkgs/android-sdk/compose.nix
@@ -5,9 +5,6 @@
 
 { androidenv, lib, stdenv }:
 
-assert lib.assertMsg (stdenv.system != "aarch64-darwin")
-  "aarch64-darwin not supported for Android SDK. Use: NIXPKGS_SYSTEM_OVERRIDE=x86_64-darwin";
-
 # The "android-sdk-license" license is accepted
 # by setting android_sdk.accept_license = true.
 androidenv.composeAndroidPackages {


### PR DESCRIPTION
The assert for Android NDK is obsolete. But we also can avoid fetching the Android dependencies when not building for Android.

Also, `lsb-release` is a linux-only tool.

It works:
```
jakubgs@macm2-01.ih-eu-mda1.ci.devel:~/nim-sds % nix build '.?submodules=1#libsds-android-arm64'
jakubgs@macm2-01.ih-eu-mda1.ci.devel:~/nim-sds % find ./result -type f
./result/libwaku.aar
./result/jni/AndroidManifest.xml
./result/jni/libsds.so
```