### PR TITLE
chore: fix nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,27 @@
 
       forAllSystems = f: nixpkgs.lib.genAttrs stableSystems (system: f system);
 
+      # Pin Nim to 2.2.8 to match the project's minimum requirement (nim >= 2.2.6).
+      # nixpkgs ships Nim 2.2.4 whose nimble segfaults in sandboxed builds.
+      # The extra-mangling patch is rebased for the 2.2.8 source tree.
+      nimOverlay = final: prev: {
+        nim-unwrapped-2_2 = prev.nim-unwrapped-2_2.overrideAttrs (old: rec {
+          version = "2.2.8";
+          src = prev.fetchurl {
+            url = "https://nim-lang.org/download/nim-${version}.tar.xz";
+            hash = "sha256-EUGRr6CDxQWdy+XOiNvk9CVCz/BOLDAXZo7kOLwLjPw=";
+          };
+          patches = builtins.filter (p:
+            !prev.lib.hasSuffix "extra-mangling-2.patch" (toString p)
+          ) old.patches ++ [
+            ./nix/patches/nim-2.2.8-extra-mangling.patch
+          ];
+          # Nim 2.2.8 has a cstring-to-string type error in excpt.nim when
+          # -d:nativeStacktrace is enabled. Drop it until upstream fixes it.
+          kochArgs = prev.lib.remove "-d:nativeStacktrace" old.kochArgs;
+        });
+      };
+
       pkgsFor = forAllSystems (
         system: import nixpkgs {
           inherit system;
@@ -30,6 +51,7 @@
             allowUnfree = true;
           };
           overlays =  [
+            nimOverlay
             (final: prev: {
               androidEnvCustom = prev.callPackage ./nix/pkgs/android-sdk { };
               androidPkgs = final.androidEnvCustom.pkgs;

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -7,19 +7,62 @@ stdenv.mkDerivation {
   inherit src;
 
   nativeBuildInputs = with pkgs; [
-    jq rsync git nimble cacert moreutils
+    jq rsync git cacert moreutils
   ];
 
   configurePhase = ''
     export XDG_CACHE_HOME=$TMPDIR
     export NIMBLE_DIR=$NIX_BUILD_TOP/nimbledir
     export HOME=$TMPDIR
+    git config --global user.email "nix@build"
+    git config --global user.name "Nix Build"
+    git config --global init.defaultBranch main
   '';
 
   buildPhase = ''
-    nimble --version
-    nimble --silent --localdeps setup
-    nimble --silent --localdeps install -y --depsOnly
+    mkdir -p $NIMBLE_DIR/pkgs2
+
+    # Read nimble.lock and clone each package at the pinned revision.
+    # This bypasses nimble entirely, avoiding its segfault when it tries
+    # to build binary targets (e.g. testutils/ntu) in the Nix sandbox.
+    for pkg in $(jq -r '.packages | keys[]' nimble.lock); do
+      url=$(jq -r ".packages.\"$pkg\".url" nimble.lock)
+      rev=$(jq -r ".packages.\"$pkg\".vcsRevision" nimble.lock)
+      ver=$(jq -r ".packages.\"$pkg\".version" nimble.lock)
+      sha1=$(jq -r ".packages.\"$pkg\".checksums.sha1" nimble.lock)
+
+      dest="$NIMBLE_DIR/pkgs2/$pkg-$ver-$sha1"
+      echo "Fetching $pkg@$ver ($rev) from $url"
+      git clone --quiet "$url" "$TMPDIR/clone_$pkg"
+      (cd "$TMPDIR/clone_$pkg" && git checkout --quiet "$rev")
+
+      mkdir -p "$dest"
+      rsync -a --exclude='.git' "$TMPDIR/clone_$pkg/" "$dest/"
+
+      # Create nimblemeta.json (nimble needs this to recognise installed packages)
+      files=$(cd "$dest" && find . -type f | sed 's|^\./|/|' | sort | jq -R . | jq -s .)
+      cat > "$dest/nimblemeta.json" <<METAEOF
+    {
+      "version": 1,
+      "metaData": {
+        "url": "$url",
+        "downloadMethod": "git",
+        "vcsRevision": "$rev",
+        "files": $files,
+        "binaries": [],
+        "specialVersions": ["$ver"]
+      }
+    }
+METAEOF
+
+      rm -rf "$TMPDIR/clone_$pkg"
+    done
+
+    # Generate nimble.paths from installed packages
+    : > nimble.paths
+    for pkg in $NIMBLE_DIR/pkgs2/*/; do
+      echo "--path:\"$pkg\"" >> nimble.paths
+    done
   '';
 
   installPhase = ''
@@ -48,8 +91,8 @@ stdenv.mkDerivation {
     done
   '';
 
-  # Make this a fixed-output derivation to allows internet access for Nimble.
-  outputHash = "sha256-OnirsXLj4HMVTbk+b4fcC+1K9MSMJyae6I7JO16WDno=";
+  # Make this a fixed-output derivation to allows internet access for git clones.
+  outputHash = "sha256-KTiUrarS6MmPksi3asJX7UQFLaNKB+a11RB6aHHPZgc=";
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
 }

--- a/nix/patches/nim-2.2.8-extra-mangling.patch
+++ b/nix/patches/nim-2.2.8-extra-mangling.patch
@@ -1,0 +1,48 @@
+--- a/compiler/modulegraphs.nim
++++ b/compiler/modulegraphs.nim
+@@ -506,7 +506,11 @@
+   for i in 0..<trunc:
+     let c = rel[i]
+     case c
+-    of 'a'..'z', '0'..'9':
++    of 'a'..'m':
++      result.add char(c.uint8 + 13)
++    of 'n'..'z':
++      result.add char(c.uint8 - 13)
++    of '0'..'9':
+       result.add c
+     of {os.DirSep, os.AltSep}:
+       result.add 'Z' # because it looks a bit like '/'
+--- a/compiler/modulepaths.nim
++++ b/compiler/modulepaths.nim
+@@ -79,6 +79,17 @@
+   else:
+     result = fileInfoIdx(conf, fullPath)
+ 
++proc rot13(result: var string) =
++  # don't mangle .nim
++  let finalIdx =
++    if result.endsWith(".nim"): result.len - 4
++    else: result.len
++  for i, c in result[0..<finalIdx]:
++    case c
++    of 'a'..'m', 'A'..'M': result[i] = char(c.uint8 + 13)
++    of 'n'..'z', 'N'..'Z': result[i] = char(c.uint8 - 13)
++    else: discard
++
+ type
+   SelectedBase = enum
+     FromProject, FromSearchPath, FromNimblePath
+@@ -109,9 +120,11 @@
+     of FromSearchPath: "@p"
+     of FromNimblePath: "@n"
+ 
+-  prefix & best.multiReplace(
++  result = prefix & best.multiReplace(
+     {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
++  rot13(result)
+ 
+ proc demangleModuleName*(path: string): string =
+   ## Demangle a relative module path.
+   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@p": "", "@n": "", "@c": ":"})
++  rot13(result)


### PR DESCRIPTION
`nix build '.#libsds'` failed with `SIGSEGV: Illegal storage access.

1. Nim version mismatch (2.2.4 vs required >= 2.2.6)
2. Nimble 0.20.1 crashes when building binary targets inside the Nix sandbox 