### PR TITLE
nix: set nim cache to proper tmp directory

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,7 +21,9 @@ in pkgs.mkShell {
   ];
 
   # Avoid compiling Nim itself.
+  # Setting nim cache to proper tmp location avoids cache collision in CI
   shellHook = ''
     export USE_SYSTEM_NIM=1
+    export XDG_CACHE_HOME="$TMPDIR"
   '';
 }


### PR DESCRIPTION
## Summary

Otherwise we end up with cache collisions like this in CI : 

```
 > Error: cannot open '/tmp/nim/libsds_d/@z..@f..@f..@f..@f..@f..
 @ffgber@f6y2zz1uv2lzi4ln2717py8m0aix64u56-avz-hajenccrq-2.2.4@favz
 @fyvo@fflfgrz@frkprcgvbaf.nim.c'
```