### PR TITLE
feat: propagate persistence backend errors via Result

### DIFF
--- a/sds.nim
+++ b/sds.nim
@@ -35,7 +35,7 @@ proc isAcknowledged*(
 
 proc reviewAckStatus(
     rm: ReliabilityManager, msg: SdsMessage
-) {.async: (raises: [CatchableError]).} =
+): Future[Result[void, ReliabilityError]] {.async: (raises: []).} =
   try:
     var rbf: Option[RollingBloomFilter]
     if msg.bloomFilter.len > 0:
@@ -59,7 +59,7 @@ proc reviewAckStatus(
       rbf = none[RollingBloomFilter]()
 
     if msg.channelId notin rm.channels:
-      return
+      return ok()
 
     let channel = rm.channels[msg.channelId]
     var toDelete: seq[(int, SdsMessageID)] = @[]
@@ -77,10 +77,12 @@ proc reviewAckStatus(
     for k in countdown(toDelete.high, 0):
       let (idx, ackedId) = toDelete[k]
       channel.outgoingBuffer.delete(idx)
-      await rm.persistence.removeOutgoing(msg.channelId, ackedId)
-  except CatchableError as e:
+      (await rm.persistence.removeOutgoing(msg.channelId, ackedId)).isOkOr:
+        return err(reliabilityErr(error))
+    ok()
+  except CatchableError:
     error "Failed to review ack status", msg = getCurrentExceptionMsg()
-    raise e
+    err(ReliabilityError.reInternalError)
 
 proc wrapOutgoingMessage*(
     rm: ReliabilityManager,
@@ -98,8 +100,10 @@ proc wrapOutgoingMessage*(
     await rm.lock.acquire()
     try:
       try:
-        let channel = await rm.getOrCreateChannel(channelId)
-        await rm.updateLamportTimestamp(getTime().toUnix, channelId)
+        let channel = (await rm.getOrCreateChannel(channelId)).valueOr:
+          return err(error)
+        (await rm.updateLamportTimestamp(getTime().toUnix, channelId)).isOkOr:
+          return err(error)
 
         let bfResult = serializeBloomFilter(channel.bloomFilter.filter)
         if bfResult.isErr:
@@ -125,13 +129,17 @@ proc wrapOutgoingMessage*(
           expiredKeys.add(eligible[i][0])
         for key in expiredKeys:
           channel.outgoingRepairBuffer.del(key)
-          await rm.persistence.removeOutgoingRepair(channelId, key)
+          (await rm.persistence.removeOutgoingRepair(channelId, key)).isOkOr:
+            return err(reliabilityErr(error))
 
+        let causalHistory = (
+          await rm.getRecentHistoryEntries(rm.config.maxCausalHistory, channelId)
+        ).valueOr:
+          return err(error)
         let msg = SdsMessage.init(
           messageId = messageId,
           lamportTimestamp = channel.lamportTimestamp,
-          causalHistory =
-            await rm.getRecentHistoryEntries(rm.config.maxCausalHistory, channelId),
+          causalHistory = causalHistory,
           channelId = channelId,
           content = message,
           bloomFilter = bfResult.get(),
@@ -143,13 +151,15 @@ proc wrapOutgoingMessage*(
           message = msg, sendTime = getTime(), resendAttempts = 0
         )
         channel.outgoingBuffer.add(unackMsg)
-        await rm.persistence.saveOutgoing(channelId, unackMsg)
+        (await rm.persistence.saveOutgoing(channelId, unackMsg)).isOkOr:
+          return err(reliabilityErr(error))
 
         channel.bloomFilter.add(msg.messageId)
         # The full SdsMessage carries senderId and content, so a single
         # addToHistory replaces the old triple-write to messageHistory,
         # messageCache, and messageSenders.
-        await rm.addToHistory(msg, channelId)
+        (await rm.addToHistory(msg, channelId)).isOkOr:
+          return err(error)
 
         return serializeMessage(msg)
       except CatchableError:
@@ -165,17 +175,17 @@ proc wrapOutgoingMessage*(
 
 proc processIncomingBuffer(
     rm: ReliabilityManager, channelId: SdsChannelID
-) {.async: (raises: [CatchableError]).} =
+): Future[Result[void, ReliabilityError]] {.async: (raises: []).} =
   try:
     await rm.lock.acquire()
     try:
       if channelId notin rm.channels:
         error "Channel does not exist", channelId = channelId
-        return
+        return ok()
 
       let channel = rm.channels[channelId]
       if channel.incomingBuffer.len == 0:
-        return
+        return ok()
 
       var processed = initHashSet[SdsMessageID]()
       var readyToProcess = newSeq[SdsMessageID]()
@@ -190,7 +200,8 @@ proc processIncomingBuffer(
           continue
 
         if msgId in channel.incomingBuffer:
-          await rm.addToHistory(channel.incomingBuffer[msgId].message, channelId)
+          (await rm.addToHistory(channel.incomingBuffer[msgId].message, channelId)).isOkOr:
+            return err(error)
           if not rm.onMessageReady.isNil():
             {.cast(raises: []).}:
               rm.onMessageReady(msgId, channelId)
@@ -200,21 +211,26 @@ proc processIncomingBuffer(
             if remainingId notin processed:
               if msgId in entry.missingDeps:
                 channel.incomingBuffer[remainingId].missingDeps.excl(msgId)
-                await rm.persistence.saveIncoming(
-                  channelId, channel.incomingBuffer[remainingId]
-                )
+                (
+                  await rm.persistence.saveIncoming(
+                    channelId, channel.incomingBuffer[remainingId]
+                  )
+                ).isOkOr:
+                  return err(reliabilityErr(error))
                 if channel.incomingBuffer[remainingId].missingDeps.len == 0:
                   readyToProcess.add(remainingId)
 
       for msgId in processed:
         channel.incomingBuffer.del(msgId)
-        await rm.persistence.removeIncoming(channelId, msgId)
+        (await rm.persistence.removeIncoming(channelId, msgId)).isOkOr:
+          return err(reliabilityErr(error))
+      ok()
     finally:
       rm.lock.release()
-  except CatchableError as e:
+  except CatchableError:
     error "Failed to process incoming buffer",
       channelId = channelId, msg = getCurrentExceptionMsg()
-    raise e
+    err(ReliabilityError.reInternalError)
 
 proc unwrapReceivedMessage*(
     rm: ReliabilityManager, message: seq[byte]
@@ -232,22 +248,27 @@ proc unwrapReceivedMessage*(
     let msg = deserializeMessage(message).valueOr:
       return err(ReliabilityError.reDeserializationError)
 
-    let channel = await rm.getOrCreateChannel(channelId)
+    let channel = (await rm.getOrCreateChannel(channelId)).valueOr:
+      return err(error)
 
     # SDS-R: opportunistic repair-buffer cleanup — applies to duplicates too,
     # so rebroadcasts cancel redundant responses on peers that already have the message.
     channel.outgoingRepairBuffer.del(msg.messageId)
-    await rm.persistence.removeOutgoingRepair(channelId, msg.messageId)
+    (await rm.persistence.removeOutgoingRepair(channelId, msg.messageId)).isOkOr:
+      return err(reliabilityErr(error))
     channel.incomingRepairBuffer.del(msg.messageId)
-    await rm.persistence.removeIncomingRepair(channelId, msg.messageId)
+    (await rm.persistence.removeIncomingRepair(channelId, msg.messageId)).isOkOr:
+      return err(reliabilityErr(error))
 
     if msg.messageId in channel.messageHistory:
       return ok((msg.content, @[], channelId))
 
     channel.bloomFilter.add(msg.messageId)
 
-    await rm.updateLamportTimestamp(msg.lamportTimestamp, channelId)
-    await rm.reviewAckStatus(msg)
+    (await rm.updateLamportTimestamp(msg.lamportTimestamp, channelId)).isOkOr:
+      return err(error)
+    (await rm.reviewAckStatus(msg)).isOkOr:
+      return err(error)
 
     # SDS-R: process incoming repair requests from this message. We can only
     # answer for messages we have actually delivered (i.e. that live in
@@ -257,7 +278,8 @@ proc unwrapReceivedMessage*(
     for repairEntry in msg.repairRequest:
       # Remove from our own outgoing repair buffer (someone else is also requesting)
       channel.outgoingRepairBuffer.del(repairEntry.messageId)
-      await rm.persistence.removeOutgoingRepair(channelId, repairEntry.messageId)
+      (await rm.persistence.removeOutgoingRepair(channelId, repairEntry.messageId)).isOkOr:
+        return err(reliabilityErr(error))
       if repairEntry.messageId in channel.messageHistory and rm.participantId.len > 0 and
           repairEntry.senderId.len > 0:
         if isInResponseGroup(
@@ -277,9 +299,12 @@ proc unwrapReceivedMessage*(
               minTimeRepairResp: now + tResp,
             )
             channel.incomingRepairBuffer[repairEntry.messageId] = inEntry
-            await rm.persistence.saveIncomingRepair(
-              channelId, repairEntry.messageId, inEntry
-            )
+            (
+              await rm.persistence.saveIncomingRepair(
+                channelId, repairEntry.messageId, inEntry
+              )
+            ).isOkOr:
+              return err(reliabilityErr(error))
 
     var missingDeps = rm.checkDependencies(msg.causalHistory, channelId)
 
@@ -293,9 +318,11 @@ proc unwrapReceivedMessage*(
         let entry =
           IncomingMessage.init(message = msg, missingDeps = initHashSet[SdsMessageID]())
         channel.incomingBuffer[msg.messageId] = entry
-        await rm.persistence.saveIncoming(channelId, entry)
+        (await rm.persistence.saveIncoming(channelId, entry)).isOkOr:
+          return err(reliabilityErr(error))
       else:
-        await rm.addToHistory(msg, channelId)
+        (await rm.addToHistory(msg, channelId)).isOkOr:
+          return err(error)
         # Unblock any buffered messages that were waiting on this one.
         var unblocked: seq[SdsMessageID] = @[]
         for pendingId, entry in channel.incomingBuffer:
@@ -303,10 +330,14 @@ proc unwrapReceivedMessage*(
             channel.incomingBuffer[pendingId].missingDeps.excl(msg.messageId)
             unblocked.add(pendingId)
         for pendingId in unblocked:
-          await rm.persistence.saveIncoming(
-            channelId, channel.incomingBuffer[pendingId]
-          )
-        await rm.processIncomingBuffer(channelId)
+          (
+            await rm.persistence.saveIncoming(
+              channelId, channel.incomingBuffer[pendingId]
+            )
+          ).isOkOr:
+            return err(reliabilityErr(error))
+        (await rm.processIncomingBuffer(channelId)).isOkOr:
+          return err(error)
         if not rm.onMessageReady.isNil():
           {.cast(raises: []).}:
             rm.onMessageReady(msg.messageId, channelId)
@@ -315,7 +346,8 @@ proc unwrapReceivedMessage*(
         message = msg, missingDeps = missingDeps.getMessageIds().toHashSet()
       )
       channel.incomingBuffer[msg.messageId] = entry
-      await rm.persistence.saveIncoming(channelId, entry)
+      (await rm.persistence.saveIncoming(channelId, entry)).isOkOr:
+        return err(reliabilityErr(error))
       if not rm.onMissingDependencies.isNil():
         {.cast(raises: []).}:
           rm.onMissingDependencies(msg.messageId, missingDeps, channelId)
@@ -331,7 +363,12 @@ proc unwrapReceivedMessage*(
             let outEntry =
               OutgoingRepairEntry(outHistEntry: dep, minTimeRepairReq: now + tReq)
             channel.outgoingRepairBuffer[dep.messageId] = outEntry
-            await rm.persistence.saveOutgoingRepair(channelId, dep.messageId, outEntry)
+            (
+              await rm.persistence.saveOutgoingRepair(
+                channelId, dep.messageId, outEntry
+              )
+            ).isOkOr:
+              return err(reliabilityErr(error))
 
     return ok((msg.content, missingDeps, channelId))
   except CatchableError:
@@ -358,15 +395,23 @@ proc markDependenciesMet*(
           channel.incomingBuffer[pendingId].missingDeps.excl(msgId)
           unblocked.add(pendingId)
       for pendingId in unblocked:
-        await rm.persistence.saveIncoming(channelId, channel.incomingBuffer[pendingId])
+        (
+          await rm.persistence.saveIncoming(
+            channelId, channel.incomingBuffer[pendingId]
+          )
+        ).isOkOr:
+          return err(reliabilityErr(error))
 
       # SDS-R: clear from repair buffers (dependency now met)
       channel.outgoingRepairBuffer.del(msgId)
-      await rm.persistence.removeOutgoingRepair(channelId, msgId)
+      (await rm.persistence.removeOutgoingRepair(channelId, msgId)).isOkOr:
+        return err(reliabilityErr(error))
       channel.incomingRepairBuffer.del(msgId)
-      await rm.persistence.removeIncomingRepair(channelId, msgId)
+      (await rm.persistence.removeIncomingRepair(channelId, msgId)).isOkOr:
+        return err(reliabilityErr(error))
 
-    await rm.processIncomingBuffer(channelId)
+    (await rm.processIncomingBuffer(channelId)).isOkOr:
+      return err(error)
     return ok()
   except CatchableError:
     error "Failed to mark dependencies as met",
@@ -399,13 +444,13 @@ proc setCallbacks*(
 
 proc checkUnacknowledgedMessages(
     rm: ReliabilityManager, channelId: SdsChannelID
-) {.async: (raises: []).} =
+): Future[Result[void, ReliabilityError]] {.async: (raises: []).} =
   try:
     await rm.lock.acquire()
     try:
       if channelId notin rm.channels:
         error "Channel does not exist", channelId = channelId
-        return
+        return ok()
 
       let channel = rm.channels[channelId]
       let now = getTime()
@@ -419,27 +464,34 @@ proc checkUnacknowledgedMessages(
             updatedMsg.resendAttempts += 1
             updatedMsg.sendTime = now
             newOutgoingBuffer.add(updatedMsg)
-            await rm.persistence.saveOutgoing(channelId, updatedMsg)
+            (await rm.persistence.saveOutgoing(channelId, updatedMsg)).isOkOr:
+              return err(reliabilityErr(error))
           else:
             if not rm.onMessageSent.isNil():
               {.cast(raises: []).}:
                 rm.onMessageSent(unackMsg.message.messageId, channelId)
-            await rm.persistence.removeOutgoing(channelId, unackMsg.message.messageId)
+            (await rm.persistence.removeOutgoing(channelId, unackMsg.message.messageId)).isOkOr:
+              return err(reliabilityErr(error))
         else:
           newOutgoingBuffer.add(unackMsg)
 
       channel.outgoingBuffer = newOutgoingBuffer
+      ok()
     finally:
       rm.lock.release()
   except CatchableError:
     error "Failed to check unacknowledged messages",
       channelId = channelId, msg = getCurrentExceptionMsg()
+    err(ReliabilityError.reInternalError)
 
 proc periodicBufferSweep(rm: ReliabilityManager) {.async: (raises: [CancelledError]).} =
   while true:
     try:
       for channelId, channel in rm.channels:
-        await rm.checkUnacknowledgedMessages(channelId)
+        # Background maintenance has no caller to return to: a persistence
+        # error is logged (by reliabilityErr) and the sweep continues; the
+        # next tick retries.
+        discard await rm.checkUnacknowledgedMessages(channelId)
         await rm.cleanBloomFilter(channelId)
     except CatchableError:
       error "Error in periodic buffer sweep", msg = getCurrentExceptionMsg()
@@ -455,13 +507,18 @@ proc periodicSyncMessage(rm: ReliabilityManager) {.async: (raises: [CancelledErr
       error "Error in periodic sync", msg = getCurrentExceptionMsg()
     await sleepAsync(chronos.seconds(rm.config.syncMessageInterval.inSeconds))
 
-proc runRepairSweep*(rm: ReliabilityManager) {.async: (raises: []).} =
+proc runRepairSweep*(
+    rm: ReliabilityManager
+): Future[Result[void, ReliabilityError]] {.async: (raises: []).} =
   ## SDS-R: Runs a single pass of the repair sweep.
   ## - Incoming: fires onRepairReady for expired T_resp entries and removes them
   ## - Outgoing: drops entries past T_max window
   ## Exposed so it can be driven directly in tests; also invoked by periodicRepairSweep.
   ## Acquires rm.lock so the repair buffers cannot be observed mid-mutation by
   ## a concurrent wrapOutgoingMessage / unwrapReceivedMessage on another task.
+  ## A persistence error aborts the current pass (the periodic caller retries
+  ## on the next tick); non-persistence per-channel errors are logged and the
+  ## sweep continues to the next channel.
   try:
     await rm.lock.acquire()
     try:
@@ -477,7 +534,8 @@ proc runRepairSweep*(rm: ReliabilityManager) {.async: (raises: []).} =
           for msgId in toRebroadcast:
             let entry = channel.incomingRepairBuffer[msgId]
             channel.incomingRepairBuffer.del(msgId)
-            await rm.persistence.removeIncomingRepair(channelId, msgId)
+            (await rm.persistence.removeIncomingRepair(channelId, msgId)).isOkOr:
+              return err(reliabilityErr(error))
             if not rm.onRepairReady.isNil():
               {.cast(raises: []).}:
                 rm.onRepairReady(entry.cachedMessage, channelId)
@@ -490,20 +548,24 @@ proc runRepairSweep*(rm: ReliabilityManager) {.async: (raises: []).} =
               toRemove.add(msgId)
           for msgId in toRemove:
             channel.outgoingRepairBuffer.del(msgId)
-            await rm.persistence.removeOutgoingRepair(channelId, msgId)
+            (await rm.persistence.removeOutgoingRepair(channelId, msgId)).isOkOr:
+              return err(reliabilityErr(error))
         except CatchableError:
           error "Error in repair sweep for channel",
             channelId = channelId, msg = getCurrentExceptionMsg()
+      ok()
     finally:
       rm.lock.release()
   except CatchableError:
     error "Error in repair sweep", msg = getCurrentExceptionMsg()
+    err(ReliabilityError.reInternalError)
 
 proc periodicRepairSweep(rm: ReliabilityManager) {.async: (raises: [CancelledError]).} =
   ## SDS-R: Periodically checks repair buffers for expired entries.
   while true:
     try:
-      await rm.runRepairSweep()
+      # Background maintenance: log a failed pass and retry next tick.
+      discard await rm.runRepairSweep()
     except CatchableError:
       error "Error in periodic repair sweep", msg = getCurrentExceptionMsg()
     await sleepAsync(chronos.milliseconds(rm.config.repairSweepInterval.inMilliseconds))
@@ -526,7 +588,8 @@ proc resetReliabilityManager*(
     try:
       try:
         for channelId, channel in rm.channels:
-          await rm.dropChannelFromPersistence(channelId)
+          (await rm.dropChannelFromPersistence(channelId)).isOkOr:
+            return err(error)
           channel.lamportTimestamp = 0
           channel.messageHistory.clear()
           channel.outgoingBuffer.setLen(0)

--- a/sds.nimble
+++ b/sds.nimble
@@ -1,7 +1,7 @@
 import strutils, os
 
 # Package
-version = "0.2.4"
+version = "0.3.0"
 author = "Logos Messaging Team"
 description = "E2E Scalable Data Sync API"
 license = "MIT"

--- a/sds/sds_utils.nim
+++ b/sds/sds_utils.nim
@@ -15,13 +15,24 @@ export
 proc defaultConfig*(): ReliabilityConfig =
   return ReliabilityConfig.init()
 
+proc reliabilityErr*(detail: string): ReliabilityError {.gcsafe, raises: [].} =
+  ## Maps a backend-supplied persistence error string onto the
+  ## `rePersistenceError` enum value. The enum carries no payload, so the
+  ## original detail is logged here — this is the single point where a
+  ## persistence failure is recorded, while the enum value travels up the
+  ## `Result` chain to the public API caller, who decides what to do.
+  warn "persistence operation failed", detail = detail
+  ReliabilityError.rePersistenceError
+
 proc dropChannelFromPersistence*(
     rm: ReliabilityManager, channelId: SdsChannelID
-) {.async: (raises: []).} =
+): Future[Result[void, ReliabilityError]] {.async: (raises: []).} =
   ## Wipes all persisted state for a channel via a single backend call.
   ## Called by removeChannel / resetReliabilityManager before they clear
   ## in-memory state. Backend executes the wipe in one transaction.
-  await rm.persistence.dropChannel(channelId)
+  (await rm.persistence.dropChannel(channelId)).isOkOr:
+    return err(reliabilityErr(error))
+  ok()
 
 proc cleanup*(rm: ReliabilityManager) {.async: (raises: []).} =
   ## Releases in-memory state. Does NOT wipe persistence — the manager may be
@@ -69,7 +80,7 @@ proc cleanBloomFilter*(
 
 proc addToHistory*(
     rm: ReliabilityManager, msg: SdsMessage, channelId: SdsChannelID
-) {.async: (raises: []).} =
+): Future[Result[void, ReliabilityError]] {.async: (raises: []).} =
   ## Inserts a delivered message into the channel's history map and evicts the
   ## eldest entries when the bound is exceeded. The full SdsMessage is kept so
   ## senderId is available for downstream causal-history population and the
@@ -78,29 +89,36 @@ proc addToHistory*(
     if channelId in rm.channels:
       let channel = rm.channels[channelId]
       channel.messageHistory[msg.messageId] = msg
-      await rm.persistence.appendLogEntry(channelId, msg)
+      (await rm.persistence.appendLogEntry(channelId, msg)).isOkOr:
+        return err(reliabilityErr(error))
       while channel.messageHistory.len > rm.config.maxMessageHistory:
         var firstKey: SdsMessageID
         for k in channel.messageHistory.keys:
           firstKey = k
           break
         channel.messageHistory.del(firstKey)
-        await rm.persistence.removeLogEntry(channelId, firstKey)
+        (await rm.persistence.removeLogEntry(channelId, firstKey)).isOkOr:
+          return err(reliabilityErr(error))
+    ok()
   except CatchableError:
     error "Failed to add to history",
       channelId = channelId, msgId = msg.messageId, error = getCurrentExceptionMsg()
+    err(ReliabilityError.reInternalError)
 
 proc updateLamportTimestamp*(
     rm: ReliabilityManager, msgTs: int64, channelId: SdsChannelID
-) {.async: (raises: []).} =
+): Future[Result[void, ReliabilityError]] {.async: (raises: []).} =
   try:
     if channelId in rm.channels:
       let channel = rm.channels[channelId]
       channel.lamportTimestamp = max(msgTs, channel.lamportTimestamp) + 1
-      await rm.persistence.saveLamport(channelId, channel.lamportTimestamp)
+      (await rm.persistence.saveLamport(channelId, channel.lamportTimestamp)).isOkOr:
+        return err(reliabilityErr(error))
+    ok()
   except CatchableError:
     error "Failed to update lamport timestamp",
       channelId = channelId, msgTs = msgTs, error = getCurrentExceptionMsg()
+    err(ReliabilityError.reInternalError)
 
 proc newHistoryEntry*(
     messageId: SdsMessageID, retrievalHint: seq[byte] = @[]
@@ -167,7 +185,7 @@ proc isInResponseGroup*(
 
 proc getRecentHistoryEntries*(
     rm: ReliabilityManager, n: int, channelId: SdsChannelID
-): Future[seq[HistoryEntry]] {.async: (raises: []).} =
+): Future[Result[seq[HistoryEntry], ReliabilityError]] {.async: (raises: []).} =
   ## Get recent history entries for sending in causal history.
   ## Populates retrieval hints and senderId (SDS-R) for each entry.
   try:
@@ -184,16 +202,17 @@ proc getRecentHistoryEntries*(
           {.cast(raises: []).}:
             entry.retrievalHint = rm.onRetrievalHint(msgId)
           if entry.retrievalHint.len > 0:
-            await rm.persistence.setRetrievalHint(msgId, entry.retrievalHint)
+            (await rm.persistence.setRetrievalHint(msgId, entry.retrievalHint)).isOkOr:
+              return err(reliabilityErr(error))
         entry.senderId = channel.messageHistory[msgId].senderId
         entries.add(entry)
-      return entries
+      ok(entries)
     else:
-      return @[]
+      ok(newSeq[HistoryEntry]())
   except CatchableError:
     error "Failed to get recent history entries",
       channelId = channelId, n = n, error = getCurrentExceptionMsg()
-    return @[]
+    err(ReliabilityError.reInternalError)
 
 proc checkDependencies*(
     rm: ReliabilityManager, deps: seq[HistoryEntry], channelId: SdsChannelID
@@ -269,7 +288,7 @@ proc getIncomingBuffer*(
 
 proc getOrCreateChannel*(
     rm: ReliabilityManager, channelId: SdsChannelID
-): Future[ChannelContext] {.async: (raises: [CatchableError]).} =
+): Future[Result[ChannelContext, ReliabilityError]] {.async: (raises: []).} =
   ## Returns the channel context, creating and bootstrapping it from the
   ## persistence backend if it does not yet exist in memory. The bloom filter
   ## is rebuilt deterministically from the loaded message history rather than
@@ -281,7 +300,8 @@ proc getOrCreateChannel*(
           rm.config.bloomFilterCapacity, rm.config.bloomFilterErrorRate
         )
       )
-      let snapshot = await rm.persistence.loadAllForChannel(channelId)
+      let snapshot = (await rm.persistence.loadAllForChannel(channelId)).valueOr:
+        return err(reliabilityErr(error))
       channel.lamportTimestamp = snapshot.lamportTimestamp
       for msg in snapshot.messageHistory:
         channel.messageHistory[msg.messageId] = msg
@@ -295,11 +315,11 @@ proc getOrCreateChannel*(
       for (msgId, entry) in snapshot.incomingRepairBuffer:
         channel.incomingRepairBuffer[msgId] = entry
       rm.channels[channelId] = channel
-    return rm.channels[channelId]
-  except CatchableError as e:
+    ok(rm.channels[channelId])
+  except CatchableError:
     error "Failed to get or create channel",
       channelId = channelId, error = getCurrentExceptionMsg()
-    raise e
+    err(ReliabilityError.reInternalError)
 
 proc ensureChannel*(
     rm: ReliabilityManager, channelId: SdsChannelID
@@ -307,13 +327,9 @@ proc ensureChannel*(
   try:
     await rm.lock.acquire()
     try:
-      try:
-        discard await rm.getOrCreateChannel(channelId)
-        return ok()
-      except CatchableError:
-        error "Failed to ensure channel",
-          channelId = channelId, msg = getCurrentExceptionMsg()
-        return err(ReliabilityError.reInternalError)
+      (await rm.getOrCreateChannel(channelId)).isOkOr:
+        return err(error)
+      return ok()
     finally:
       rm.lock.release()
   except CatchableError:
@@ -330,7 +346,8 @@ proc removeChannel*(
       try:
         if channelId in rm.channels:
           let channel = rm.channels[channelId]
-          await rm.dropChannelFromPersistence(channelId)
+          (await rm.dropChannelFromPersistence(channelId)).isOkOr:
+            return err(error)
           channel.outgoingBuffer.setLen(0)
           channel.incomingBuffer.clear()
           channel.messageHistory.clear()

--- a/sds/types/persistence.nim
+++ b/sds/types/persistence.nim
@@ -1,11 +1,12 @@
-import chronos
+import chronos, results
 import ./sds_message_id
 import ./sds_message
 import ./unacknowledged_message
 import ./incoming_message
 import ./repair_entry
 export
-  sds_message_id, sds_message, unacknowledged_message, incoming_message, repair_entry
+  results, sds_message_id, sds_message, unacknowledged_message, incoming_message,
+  repair_entry
 
 ## SDS state persistence interface (issue #64).
 ##
@@ -17,6 +18,14 @@ export
 ##
 ## All proc fields are async (return `Future`) so backends can do real I/O
 ## without blocking the Chronos event loop the manager runs on.
+##
+## Every field returns a `Result` so backend failures are propagated to nim-sds
+## rather than swallowed by the backend. Mutating ops return
+## `Result[void, string]`; the getter (`loadAllForChannel`) returns
+## `Result[ChannelSnapshot, string]`. The error is a backend-supplied message;
+## nim-sds maps it to `ReliabilityError.rePersistenceError` and surfaces it on
+## the corresponding public API call. The contract still forbids raising
+## (`raises: []`): failure must travel through the `Result`, not an exception.
 ##
 ## Bloom filter is intentionally not persisted: it is rebuilt from the local
 ## history log on bootstrap. Async timers are likewise recomputed from the
@@ -44,120 +53,125 @@ type
     ## in-memory state in lockstep without blocking the event loop.
 
     # Per-channel lamport clock
-    saveLamport*: proc(channelId: SdsChannelID, lamport: int64): Future[void] {.
-      async: (raises: []), gcsafe
-    .}
+    saveLamport*: proc(
+      channelId: SdsChannelID, lamport: int64
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
 
     # Local log (delivered messages)
-    appendLogEntry*: proc(channelId: SdsChannelID, msg: SdsMessage): Future[void] {.
-      async: (raises: []), gcsafe
-    .}
-    removeLogEntry*: proc(channelId: SdsChannelID, msgId: SdsMessageID): Future[void] {.
-      async: (raises: []), gcsafe
-    .}
-    setRetrievalHint*: proc(msgId: SdsMessageID, hint: seq[byte]): Future[void] {.
-      async: (raises: []), gcsafe
-    .}
+    appendLogEntry*: proc(
+      channelId: SdsChannelID, msg: SdsMessage
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
+    removeLogEntry*: proc(
+      channelId: SdsChannelID, msgId: SdsMessageID
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
+    setRetrievalHint*: proc(
+      msgId: SdsMessageID, hint: seq[byte]
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
 
     # Outgoing unacknowledged buffer
     saveOutgoing*: proc(
       channelId: SdsChannelID, msg: UnacknowledgedMessage
-    ): Future[void] {.async: (raises: []), gcsafe.}
-    removeOutgoing*: proc(channelId: SdsChannelID, msgId: SdsMessageID): Future[void] {.
-      async: (raises: []), gcsafe
-    .}
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
+    removeOutgoing*: proc(
+      channelId: SdsChannelID, msgId: SdsMessageID
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
 
     # Incoming dependency-waiting buffer
-    saveIncoming*: proc(channelId: SdsChannelID, msg: IncomingMessage): Future[void] {.
-      async: (raises: []), gcsafe
-    .}
-    removeIncoming*: proc(channelId: SdsChannelID, msgId: SdsMessageID): Future[void] {.
-      async: (raises: []), gcsafe
-    .}
+    saveIncoming*: proc(
+      channelId: SdsChannelID, msg: IncomingMessage
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
+    removeIncoming*: proc(
+      channelId: SdsChannelID, msgId: SdsMessageID
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
 
     # SDS-R outgoing repair buffer
     saveOutgoingRepair*: proc(
       channelId: SdsChannelID, msgId: SdsMessageID, entry: OutgoingRepairEntry
-    ) {.async: (raises: []).}
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
     removeOutgoingRepair*: proc(
       channelId: SdsChannelID, msgId: SdsMessageID
-    ): Future[void] {.async: (raises: []), gcsafe.}
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
 
     # SDS-R incoming repair buffer
     saveIncomingRepair*: proc(
       channelId: SdsChannelID, msgId: SdsMessageID, entry: IncomingRepairEntry
-    ) {.async: (raises: []).}
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
     removeIncomingRepair*: proc(
       channelId: SdsChannelID, msgId: SdsMessageID
-    ): Future[void] {.async: (raises: []), gcsafe.}
+    ): Future[Result[void, string]] {.async: (raises: []), gcsafe.}
 
     # Wipe all persisted state for a channel in one transactional call.
     # Called by removeChannel / resetReliabilityManager. Backends should
     # implement this atomically (e.g. one BEGIN/COMMIT) — a per-row loop on
     # the nim-sds side would mean N fsyncs per drop.
-    dropChannel*:
-      proc(channelId: SdsChannelID): Future[void] {.async: (raises: []), gcsafe.}
-
-    # Bootstrap on `addChannel` / `getOrCreateChannel`.
-    loadAllForChannel*: proc(channelId: SdsChannelID): Future[ChannelSnapshot] {.
+    dropChannel*: proc(channelId: SdsChannelID): Future[Result[void, string]] {.
       async: (raises: []), gcsafe
     .}
+
+    # Bootstrap on `addChannel` / `getOrCreateChannel`.
+    loadAllForChannel*: proc(
+      channelId: SdsChannelID
+    ): Future[Result[ChannelSnapshot, string]] {.async: (raises: []), gcsafe.}
 
 proc noOpPersistence*(): Persistence =
   ## Default backend that discards every write and returns an empty snapshot.
   ## Used so existing callers (and tests) that don't care about durability
   ## keep working without supplying a real backend.
   Persistence(
-    saveLamport: proc(channelId: SdsChannelID, lamport: int64) {.async: (raises: []).} =
-      discard,
+    saveLamport: proc(
+        channelId: SdsChannelID, lamport: int64
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     appendLogEntry: proc(
         channelId: SdsChannelID, msg: SdsMessage
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     removeLogEntry: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     setRetrievalHint: proc(
         msgId: SdsMessageID, hint: seq[byte]
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     saveOutgoing: proc(
         channelId: SdsChannelID, msg: UnacknowledgedMessage
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     removeOutgoing: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     saveIncoming: proc(
         channelId: SdsChannelID, msg: IncomingMessage
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     removeIncoming: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     saveOutgoingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID, entry: OutgoingRepairEntry
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     removeOutgoingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     saveIncomingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID, entry: IncomingRepairEntry
-    ) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     removeIncomingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
-      discard,
-    dropChannel: proc(channelId: SdsChannelID) {.async: (raises: []).} =
-      discard,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
+    dropChannel: proc(
+        channelId: SdsChannelID
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ok(),
     loadAllForChannel: proc(
         channelId: SdsChannelID
-    ): Future[ChannelSnapshot] {.async: (raises: []).} =
-      return ChannelSnapshot(),
+    ): Future[Result[ChannelSnapshot, string]] {.async: (raises: []).} =
+      ok(ChannelSnapshot()),
   )

--- a/sds/types/reliability_error.nim
+++ b/sds/types/reliability_error.nim
@@ -5,3 +5,4 @@ type ReliabilityError* {.pure.} = enum
   reSerializationError
   reDeserializationError
   reMessageTooLarge
+  rePersistenceError ## A persistence backend operation (read or write) failed.

--- a/tests/in_memory_persistence.nim
+++ b/tests/in_memory_persistence.nim
@@ -1,4 +1,4 @@
-import std/tables
+import std/[tables, sets]
 import chronos
 import sds
 
@@ -6,6 +6,11 @@ import sds
 ## full write → restart → read-back loop without depending on SQLite (or any
 ## real storage technology). Exposes the underlying store so tests can assert
 ## on what got saved.
+##
+## `failingOps` injects backend failures: any op whose name is in the set
+## returns `err(...)` instead of performing the operation, so tests can verify
+## that nim-sds propagates the failure as `rePersistenceError`. Op names match
+## the `Persistence` field names (e.g. "appendLogEntry", "loadAllForChannel").
 
 type InMemoryStore* = ref object
   lamports*: Table[SdsChannelID, int64]
@@ -18,92 +23,124 @@ type InMemoryStore* = ref object
   dropChannelCalls*: Table[SdsChannelID, int]
     ## Per-channel counter; lets tests assert dropChannel is invoked exactly
     ## once per logical drop (not N times — see PR #66 review).
+  failingOps*: HashSet[string]
+    ## Op names that should return an injected backend error. See module doc.
 
 proc newInMemoryStore*(): InMemoryStore =
-  InMemoryStore()
+  InMemoryStore(failingOps: initHashSet[string]())
+
+proc failInjected(store: InMemoryStore, op: string): Result[void, string] =
+  ## Returns err(...) when `op` is registered in `failingOps`, ok() otherwise.
+  if op in store.failingOps:
+    return err("injected backend failure: " & op)
+  ok()
 
 proc newInMemoryPersistence*(store: InMemoryStore): Persistence =
   Persistence(
-    saveLamport: proc(channelId: SdsChannelID, lamport: int64) {.async: (raises: []).} =
-      store.lamports[channelId] = lamport,
+    saveLamport: proc(
+        channelId: SdsChannelID, lamport: int64
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("saveLamport")
+      store.lamports[channelId] = lamport
+      ok(),
     appendLogEntry: proc(
         channelId: SdsChannelID, msg: SdsMessage
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("appendLogEntry")
       {.cast(raises: []).}:
         if channelId notin store.log:
           store.log[channelId] = initOrderedTable[SdsMessageID, SdsMessage]()
-        store.log[channelId][msg.messageId] = msg,
+        store.log[channelId][msg.messageId] = msg
+      ok(),
     removeLogEntry: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("removeLogEntry")
       {.cast(raises: []).}:
         if channelId in store.log:
           store.log[channelId].del(msgId)
-    ,
+      ok(),
     setRetrievalHint: proc(
         msgId: SdsMessageID, hint: seq[byte]
-    ) {.async: (raises: []).} =
-      store.hints[msgId] = hint,
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("setRetrievalHint")
+      store.hints[msgId] = hint
+      ok(),
     saveOutgoing: proc(
         channelId: SdsChannelID, msg: UnacknowledgedMessage
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("saveOutgoing")
       {.cast(raises: []).}:
         if channelId notin store.outgoing:
           store.outgoing[channelId] =
             initOrderedTable[SdsMessageID, UnacknowledgedMessage]()
-        store.outgoing[channelId][msg.message.messageId] = msg,
+        store.outgoing[channelId][msg.message.messageId] = msg
+      ok(),
     removeOutgoing: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("removeOutgoing")
       {.cast(raises: []).}:
         if channelId in store.outgoing:
           store.outgoing[channelId].del(msgId)
-    ,
+      ok(),
     saveIncoming: proc(
         channelId: SdsChannelID, msg: IncomingMessage
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("saveIncoming")
       {.cast(raises: []).}:
         if channelId notin store.incoming:
           store.incoming[channelId] = initOrderedTable[SdsMessageID, IncomingMessage]()
-        store.incoming[channelId][msg.message.messageId] = msg,
+        store.incoming[channelId][msg.message.messageId] = msg
+      ok(),
     removeIncoming: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("removeIncoming")
       {.cast(raises: []).}:
         if channelId in store.incoming:
           store.incoming[channelId].del(msgId)
-    ,
+      ok(),
     saveOutgoingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID, entry: OutgoingRepairEntry
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("saveOutgoingRepair")
       {.cast(raises: []).}:
         if channelId notin store.outgoingRepair:
           store.outgoingRepair[channelId] =
             initOrderedTable[SdsMessageID, OutgoingRepairEntry]()
-        store.outgoingRepair[channelId][msgId] = entry,
+        store.outgoingRepair[channelId][msgId] = entry
+      ok(),
     removeOutgoingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("removeOutgoingRepair")
       {.cast(raises: []).}:
         if channelId in store.outgoingRepair:
           store.outgoingRepair[channelId].del(msgId)
-    ,
+      ok(),
     saveIncomingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID, entry: IncomingRepairEntry
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("saveIncomingRepair")
       {.cast(raises: []).}:
         if channelId notin store.incomingRepair:
           store.incomingRepair[channelId] =
             initOrderedTable[SdsMessageID, IncomingRepairEntry]()
-        store.incomingRepair[channelId][msgId] = entry,
+        store.incomingRepair[channelId][msgId] = entry
+      ok(),
     removeIncomingRepair: proc(
         channelId: SdsChannelID, msgId: SdsMessageID
-    ) {.async: (raises: []).} =
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("removeIncomingRepair")
       {.cast(raises: []).}:
         if channelId in store.incomingRepair:
           store.incomingRepair[channelId].del(msgId)
-    ,
-    dropChannel: proc(channelId: SdsChannelID) {.async: (raises: []).} =
+      ok(),
+    dropChannel: proc(
+        channelId: SdsChannelID
+    ): Future[Result[void, string]] {.async: (raises: []).} =
+      ?store.failInjected("dropChannel")
       {.cast(raises: []).}:
         store.lamports.del(channelId)
         store.log.del(channelId)
@@ -112,10 +149,13 @@ proc newInMemoryPersistence*(store: InMemoryStore): Persistence =
         store.outgoingRepair.del(channelId)
         store.incomingRepair.del(channelId)
         store.dropChannelCalls[channelId] =
-          store.dropChannelCalls.getOrDefault(channelId) + 1,
+          store.dropChannelCalls.getOrDefault(channelId) + 1
+      ok(),
     loadAllForChannel: proc(
         channelId: SdsChannelID
-    ): Future[ChannelSnapshot] {.async: (raises: []).} =
+    ): Future[Result[ChannelSnapshot, string]] {.async: (raises: []).} =
+      if "loadAllForChannel" in store.failingOps:
+        return err("injected backend failure: loadAllForChannel")
       {.cast(raises: []).}:
         var snap = ChannelSnapshot()
         if channelId in store.lamports:
@@ -135,5 +175,5 @@ proc newInMemoryPersistence*(store: InMemoryStore): Persistence =
         if channelId in store.incomingRepair:
           for msgId, entry in store.incomingRepair[channelId]:
             snap.incomingRepairBuffer.add((msgId, entry))
-        return snap,
+        return ok(snap),
   )

--- a/tests/test_persistence.nim
+++ b/tests/test_persistence.nim
@@ -34,7 +34,7 @@ suite "Persistence: write → restart → read-back":
     let p1 = newInMemoryPersistence(store)
     let rm1 = newReliabilityManager(participantId = "alice", persistence = p1).get()
     check (await rm1.ensureChannel(testChannel)).isOk()
-    await rm1.updateLamportTimestamp(42, testChannel)
+    check (await rm1.updateLamportTimestamp(42, testChannel)).isOk()
     check store.lamports[testChannel] == 43 # max(42, 0) + 1
     await rm1.cleanup()
 
@@ -57,7 +57,7 @@ suite "Persistence: write → restart → read-back":
       bloomFilter = @[],
       senderId = "alice",
     )
-    await rm1.addToHistory(msg, testChannel)
+    check (await rm1.addToHistory(msg, testChannel)).isOk()
     check store.log[testChannel].len == 1
     await rm1.cleanup()
 
@@ -276,7 +276,7 @@ suite "Persistence: write → restart → read-back":
         bloomFilter = @[],
         senderId = "alice",
       )
-      await rm1.addToHistory(m, testChannel)
+      check (await rm1.addToHistory(m, testChannel)).isOk()
     check store.log[testChannel].len == 3
     check "m1" notin store.log[testChannel]
     check "m2" notin store.log[testChannel]
@@ -305,7 +305,7 @@ suite "Persistence: write → restart → read-back":
       bloomFilter = @[],
       senderId = "alice",
     )
-    await rm2.addToHistory(m6, testChannel)
+    check (await rm2.addToHistory(m6, testChannel)).isOk()
     check "m3" notin store.log[testChannel]
     check "m6" in store.log[testChannel]
     await rm2.cleanup()
@@ -368,3 +368,40 @@ suite "Persistence: write → restart → read-back":
     let inbufFinal = await rm2.getIncomingBuffer(testChannel)
     check inbufFinal.len == 0
     await rm2.cleanup()
+
+suite "Persistence: error propagation":
+  asyncTest "loadAllForChannel failure surfaces as rePersistenceError":
+    let store = newInMemoryStore()
+    store.failingOps.incl("loadAllForChannel")
+    let rm = newReliabilityManager(
+        participantId = "alice", persistence = newInMemoryPersistence(store)
+      )
+      .get()
+    let res = await rm.ensureChannel(testChannel)
+    check res.isErr()
+    check res.error == ReliabilityError.rePersistenceError
+
+  asyncTest "write failure during send surfaces as rePersistenceError":
+    let store = newInMemoryStore()
+    let rm = newReliabilityManager(
+        participantId = "alice", persistence = newInMemoryPersistence(store)
+      )
+      .get()
+    check (await rm.ensureChannel(testChannel)).isOk()
+    # Make the outgoing-buffer write fail; wrapOutgoingMessage must not swallow it.
+    store.failingOps.incl("saveOutgoing")
+    let res = await rm.wrapOutgoingMessage(@[byte(1)], "m1", testChannel)
+    check res.isErr()
+    check res.error == ReliabilityError.rePersistenceError
+
+  asyncTest "dropChannel failure during removeChannel surfaces as rePersistenceError":
+    let store = newInMemoryStore()
+    let rm = newReliabilityManager(
+        participantId = "alice", persistence = newInMemoryPersistence(store)
+      )
+      .get()
+    check (await rm.ensureChannel(testChannel)).isOk()
+    store.failingOps.incl("dropChannel")
+    let res = await rm.removeChannel(testChannel)
+    check res.isErr()
+    check res.error == ReliabilityError.rePersistenceError

--- a/tests/test_reliability.nim
+++ b/tests/test_reliability.nim
@@ -1550,7 +1550,7 @@ suite "SDS-R: Lifecycle and State":
 
     discard await rm.wrapOutgoingMessage(@[byte(1)], "m1", testChannel)
     discard await rm.wrapOutgoingMessage(@[byte(2)], "m2", testChannel)
-    let entries = await rm.getRecentHistoryEntries(10, testChannel)
+    let entries = (await rm.getRecentHistoryEntries(10, testChannel)).get()
     check:
       entries.len == 2
       entries[0].senderId == "alice"
@@ -1704,7 +1704,7 @@ suite "SDS-R: Repair Sweep":
       minTimeRepairResp: getTime() + initDuration(minutes = 10), # far future
     )
 
-    await rm.runRepairSweep()
+    check (await rm.runRepairSweep()).isOk()
 
     check:
       fireCount == 1
@@ -1733,7 +1733,7 @@ suite "SDS-R: Repair Sweep":
       minTimeRepairReq: getTime(),
     )
 
-    await rm.runRepairSweep()
+    check (await rm.runRepairSweep()).isOk()
 
     check:
       "m-stale" notin channel.outgoingRepairBuffer
@@ -1751,7 +1751,7 @@ suite "SDS-R: Repair Sweep":
       onRepairReady = proc(bytes: seq[byte], ch: SdsChannelID) {.gcsafe.} =
         fireCount += 1,
     )
-    await rm.runRepairSweep()
+    check (await rm.runRepairSweep()).isOk()
     check fireCount == 0
 
 # --- Multi-participant in-process bus for integration tests ---------------
@@ -1890,7 +1890,7 @@ suite "SDS-R: Multi-Participant Integration":
     # Force alice's tResp to past just to be safe (it's already 0 for self),
     # then run her sweep. She rebroadcasts M1.
     alice.forceIncomingExpired("m1")
-    await alice.runRepairSweep()
+    check (await alice.runRepairSweep()).isOk()
     await bus.drain()
 
     # Bob now has M1 and M2 delivered.
@@ -1922,7 +1922,7 @@ suite "SDS-R: Multi-Participant Integration":
     # Alice fires first (T_resp =0 for self). Her rebroadcast should cancel Carol's
     # pending entry when Carol receives the rebroadcast.
     alice.forceIncomingExpired("m1")
-    await alice.runRepairSweep()
+    check (await alice.runRepairSweep()).isOk()
     await bus.drain()
 
     # Carol's pending response must have been cleared by the dedup-path cleanup.
@@ -1930,7 +1930,7 @@ suite "SDS-R: Multi-Participant Integration":
 
     # Even if we now force-run Carol's sweep, nothing should fire.
     let wireCountBefore = bus.wireLog.len
-    await carol.runRepairSweep()
+    check (await carol.runRepairSweep()).isOk()
     await bus.drain()
     check bus.wireLog.len == wireCountBefore
 


### PR DESCRIPTION
## Summary

The `Persistence` contract returned `Future[void]` for writes and `Future[ChannelSnapshot]` for the loader, all `raises: []`. Backends had **no channel to report a failure**, so:

- a failed write was silently swallowed by the backend, and
- on the read path, a mid-scan failure could bootstrap a **truncated** channel snapshot — corrupting the rebuilt bloom filter and lamport clock across a restart (worse than returning nothing).

This makes the contract transparent: failures travel up to the public API, where the **caller** decides what to do, rather than the backend deciding to swallow.

## What changed

- **Contract** (`sds/types/persistence.nim`): every field is now `Result`-returning.
  - mutating ops → `Future[Result[void, string]]`
  - `loadAllForChannel` → `Future[Result[ChannelSnapshot, string]]`
  - still `raises: []` — failure travels through the `Result`, not an exception.
- **New error** `ReliabilityError.rePersistenceError`. A `reliabilityErr(detail)` helper logs the backend-supplied string once at the boundary and maps it to the enum.
- **Propagation**: every persistence-touching proc (`addToHistory`, `updateLamportTimestamp`, `getRecentHistoryEntries`, `dropChannelFromPersistence`, `getOrCreateChannel`, `reviewAckStatus`, `processIncomingBuffer`, `checkUnacknowledgedMessages`, `runRepairSweep`) now returns `Result[_, ReliabilityError]` and threads the error up.
- **Decision point = background loops**: `periodicBufferSweep` / `periodicRepairSweep` log a failed pass and retry next tick — they have no synchronous caller to return to. Request-driven paths (`wrap`/`unwrap`/`markDependenciesMet`/`ensureChannel`/`removeChannel`/`reset`) propagate the error to their existing `Result[_, ReliabilityError]`.

## Tests

- In-memory test backend gains a `failingOps` injection hook.
- New **"Persistence: error propagation"** suite asserts that read / write / drop failures surface as `rePersistenceError`.
- Full suite passes locally (`nimble test`, 90 `[OK]`, exit 0).

## Breaking change

The `Persistence` contract signature changed — custom backends must return `Result` and `ok()` on success. Version bumped **0.2.4 → 0.3.0**. Downstream (logos-delivery) must update its glue + `nimble.lock` (+ nix `outputHash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)