### PR TITLE
fix: relax nim-ffi floor to >= 0.1.3 (only library uses it)

### DIFF
--- a/sds.nimble
+++ b/sds.nimble
@@ -16,7 +16,9 @@ requires "stew"
 requires "stint"
 requires "metrics"
 requires "results"
-requires "https://github.com/logos-messaging/nim-ffi >= 0.1.4"
+# Only library/ (the FFI wrapper) uses nim-ffi, not core sds/. Keep the floor
+# low so core-only consumers aren't forced up; nimble.lock pins library/'s version.
+requires "https://github.com/logos-messaging/nim-ffi >= 0.1.3"
 
 proc buildLibrary(
     outLibNameAndExt: string,


### PR DESCRIPTION
## Problem
nim-sds requires `nim-ffi >= 0.1.4`, forcing that version on every consumer, even nim projects that only `import sds` and never use the FFI wrapper. since nim-ffi resolves to one version graph-wide, this conflicts with consumers already on 0.1.3 (e.g. logos-delivery).

