### PR TITLE
fix(ios): localize Nim runtime symbols in libsds static library

### DIFF
--- a/sds.nimble
+++ b/sds.nimble
@@ -153,7 +153,6 @@ proc buildMobileIOS(srcDir = ".", sdkPath = "") =
     quit "Error: Xcode/iOS SDK not found"
 
   let aFile = outDir & "/libsds.a"
-  let aFileTmp = outDir & "/libsds_tmp.a"
   let cpu = getMyCpu()
   let clangArch = if cpu == "amd64": "x86_64" else: cpu
 
@@ -186,17 +185,17 @@ proc buildMobileIOS(srcDir = ".", sdkPath = "") =
       exec "clang " & clangFlags & " -c " & cFile & " -o " & oFile
       objectFiles.add(oFile)
 
-  # 3) Create static library from all object files
-  exec "ar rcs " & aFileTmp & " " & objectFiles.join(" ")
-
-  # 4) Use libtool to localize all non-public symbols
-  # Keep only Sds* functions as global, hide everything else to prevent conflicts
-  # with nim runtime symbols from libnim_status_client
-  let keepSymbols =
-    "_Sds*:_libsdsNimMain:_libsdsDatInit*:_libsdsInit*:_NimMainModule__libsds*"
-  exec "xcrun libtool -static -o " & aFile & " " & aFileTmp &
-    " -exported_symbols_list /dev/stdin <<< '" & keepSymbols & "' 2>/dev/null || cp " &
-    aFileTmp & " " & aFile
+  # 3) Merge into one object exporting only the _Sds* API, so libsds's Nim runtime
+  #    can't clash with other static Nim libs (e.g. libnim_status_client).
+  #    (libtool -static ignores -exported_symbols_list on current Xcode; ld -r works.
+  #    Objects go through a response file: too many long paths for one command line.)
+  let objListFile = outDir & "/objects.txt"
+  writeFile(objListFile, objectFiles.join("\n"))
+  let mergedObj = outDir & "/libsds_merged.o"
+  exec "xcrun ld -r -arch " & clangArch & " -exported_symbol '_Sds*' -o " & mergedObj &
+    " @" & objListFile
+  exec "ar rcs " & aFile & " " & mergedObj
+  exec "rm -f " & mergedObj & " " & objListFile
 
   echo "✔ iOS library created: " & aFile
 

--- a/sds.nimble
+++ b/sds.nimble
@@ -193,7 +193,7 @@ proc buildMobileIOS(srcDir = ".", sdkPath = "") =
   writeFile(objListFile, objectFiles.join("\n"))
   let mergedObj = outDir & "/libsds_merged.o"
   exec "xcrun ld -r -arch " & clangArch & " -exported_symbol '_Sds*' -o " & mergedObj &
-    " @" & objListFile
+    " -filelist " & objListFile
   exec "ar rcs " & aFile & " " & mergedObj
   exec "rm -f " & mergedObj & " " & objListFile
 


### PR DESCRIPTION
Replace libtool `-exported_symbols_list` (ignored for static archives on current Xcode, with a silent fallback to unlocalized objects) with `ld -r -exported_symbol '_Sds*'`, so libsds.a no longer exports global Nim runtime symbols that collide with libnim_status_client.