### PR TITLE
ci(nix): run nix builds on GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -24,10 +24,10 @@ jobs:
 
         include:
           - system: aarch64-darwin
-            runs_on: [self-hosted, macOS, ARM64]
+            runs_on: macos-latest
 
           - system: x86_64-linux
-            runs_on: [self-hosted, Linux, X64]
+            runs_on: ubuntu-latest
 
         # Nimble segfaults on MacOS hosts.
         exclude:
@@ -47,11 +47,14 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: logos-co/setup-nix-cache-action@v1
+        with:
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+
       - name: 'Run Nix build for ${{ matrix.nixpkg }}'
         shell: bash
-        run: |
-          nix build -L '.#${{ matrix.nixpkg }}' \
-            --print-out-paths --accept-flake-config
+        run: nix build -L '.#${{ matrix.nixpkg }}'
 
       - name: 'Show result contents'
         shell: bash

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -6,6 +6,9 @@ permissions:
 on:
   pull_request:
     branches: [master, release/*]
+  push:
+    branches: [master, release/*]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -42,6 +42,8 @@ jobs:
 
     name: '${{ matrix.system }} / ${{ matrix.nixpkg }}'
     runs-on: ${{ matrix.runs_on }}
+    # ATTIC_TOKEN_PUBLIC only exists in the public-cache environment.
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,10 @@
   description = "Nim-SDS build flake";
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.status.im/" ];
-    extra-trusted-public-keys = [ "nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY=" ];
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [
+      "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU="
+    ];
   };
 
   inputs = {


### PR DESCRIPTION
# Description

1. Moved the `ci / nix` matrix from self-hosted runners to `ubuntu-latest` / `macos-latest`. The self-hosted fleet was rebuilt in the late-July/August migration and this repo was never added to the new `logos enterprise` runner group, so every nix job has sat QUEUED since — #90 merged with all six never started.
2. Added `logos-co/setup-nix-cache-action@v1` for the Logos Attic cache, as in logos-delivery. `ATTIC_TOKEN_CI` and the `public-cache` environment already exist here.
3. Pointed `flake.nix` `nixConfig` at `cache.nix.logos.co/public` instead of `nix-cache.status.im`.
4. Added `push` and `workflow_dispatch` triggers, matching the nimble workflow. Master pushes enter the `public-cache` environment, so the public cache gets populated from here instead of only the `ci` one.

<details>
<summary>AI-made decisions</summary>

- Mirrored the nimble workflow's trigger list rather than adding `push` alone; `workflow_dispatch` is useful for re-seeding the public cache by hand.
- No `concurrency` group, unlike logos-delivery-module — cancelling an in-flight master run would drop a cache-seeding build.
- Dropped `--print-out-paths --accept-flake-config` from the build step to match logos-delivery; the action configures both substituters itself.
- Kept the `libsds-ios` package out of the matrix, as before — the nimble workflow already covers it on macOS.

</details>
