### PR TITLE
feat: let a Nimble dependent build libsds from the installed package

### DIFF
--- a/sds.nimble
+++ b/sds.nimble
@@ -7,6 +7,10 @@ description = "E2E Scalable Data Sync API"
 license = "MIT"
 srcDir = "sds"
 
+# A dependent builds libsds from the installed package, so ship library/ too.
+# Naming any directory turns off the default srcDir install, hence sds/ here.
+installDirs = @["library", "sds"]
+
 # Dependencies
 requires "nim >= 2.2.4"
 requires "chronos >= 4.0.4"
@@ -16,6 +20,9 @@ requires "stew"
 requires "stint"
 requires "metrics"
 requires "results"
+# nim-ffi imports taskpools/channels_spsc_single, dropped in 0.2.x, and asks
+# for taskpools unconstrained. nimble.lock already resolves 0.1.0.
+requires "taskpools < 0.2.0"
 requires "https://github.com/logos-messaging/nim-ffi#v0.1.5"
 
 proc buildLibrary(
@@ -28,19 +35,22 @@ proc buildLibrary(
   if not dirExists "build":
     mkDir "build"
 
+  # An embedder that resolves dependencies itself passes --path here.
+  let params = extra_params & " " & getEnv("NIM_PARAMS")
+
   if `type` == "static":
     exec "nim c" & " --out:build/" & outLibNameAndExt &
       " --threads:on --app:staticlib --opt:size --noMain --mm:refc --header --nimMainPrefix:libsds -d:noSignalHandler " &
-      extra_params & " " & srcDir & name & ".nim"
+      params & " " & srcDir & name & ".nim"
   else:
     when defined(windows):
       exec "nim c" & " --out:build/" & outLibNameAndExt &
         " --threads:on --app:lib --opt:size --noMain --mm:refc --header --nimMainPrefix:libsds -d:noSignalHandler " &
-        extra_params & " " & srcDir & name & ".nim"
+        params & " " & srcDir & name & ".nim"
     else:
       exec "nim c" & " --out:build/" & outLibNameAndExt &
         " --threads:on --app:lib --opt:size --noMain --mm:refc --header --nimMainPrefix:libsds -d:noSignalHandler " &
-        extra_params & " " & srcDir & name & ".nim"
+        params & " " & srcDir & name & ".nim"
 
 proc getMyCpu(): string =
   ## Returns a Nim-compatible CPU name (e.g. amd64, arm64) for the host.


### PR DESCRIPTION
# Description

1. Added `installDirs = @["library", "sds"]`. The installed package held only `srcDir`, so a dependent got no `library/` — no `libsds.h` to link against and nothing for the build task to compile. `sds` is listed because naming any directory turns off the default `srcDir` install.
2. Constrained `taskpools < 0.2.0`. nim-ffi imports `taskpools/channels_spsc_single`, dropped in 0.2.x, and asks for taskpools unconstrained, so a fresh resolve picks 0.2.1 and fails to compile. `nimble.lock` has long settled on 0.1.0; this makes the unlocked resolution agree with it.
3. Forwarded `NIM_PARAMS` into the build tasks. They ignored the environment, so an embedder that resolves dependencies itself had no way to pass its `--path` set in — and the package is installed outside the consumer's tree, where Nim finds no ancestor `config.nims`.

Verified on a cold cache from a consumer package: `nimble setup --localdeps` then `nimble libsds` in the installed package produces `libsds.so` exporting the nine `sds_*` entry points, with `libsds.h` alongside it.

<details>
<summary>AI-made decisions</summary>

- Point 2 papers over a nim-ffi bug — nim-ffi v0.1.5 should declare the constraint itself. Doing it here keeps the fix in the repo whose lock file already records the right answer; worth an upstream follow-up either way.
- `NIM_PARAMS` rather than `NIMFLAGS`, to match what logos-delivery's nimble file already reads.
- Overlaps the older draft #85, which bundles this with static-Mac symbol localization and `ZERO_AR_DATE`. Kept to just what unblocks a Nimble dependent; the rest of #85 stands on its own.
</details>
